### PR TITLE
g++ compatibility

### DIFF
--- a/ASCII_Lib.cpp
+++ b/ASCII_Lib.cpp
@@ -1,7 +1,4 @@
-#include "SDL.h"
-#include "def.h"
-#include <math.h>
-
+#include "ASCII_Lib.h"
 void drawChr(int x, int y, int smiley, SDL_Surface* source, SDL_Surface* destination, Uint32 color)
 {
     //Holds offsets
@@ -40,7 +37,7 @@ void drawStr(int x, int y, char stringy[], SDL_Surface* source, SDL_Surface* des
     }
 }
 
-void drawInt(int x, int y, int number, SDL_Surface* source, SDL_Surface* destination, Uint32 color, int size = 0)
+void drawInt(int x, int y, int number, SDL_Surface* source, SDL_Surface* destination, Uint32 color, int size)
 {
     // Note that numbers do not erase before redrawing and are left-justified
     // For example, if you print '17', then in the same location print '5',
@@ -54,7 +51,7 @@ void drawInt(int x, int y, int number, SDL_Surface* source, SDL_Surface* destina
         for ( int i = 0; i < (size-1); i++ ) { exp = exp*10; }
         number = number + exp;
     }
-    itoa(number, buf, 10);
+    //itoa(number, buf, 10);
     if ( size > 1 )
     {
         buf[0] = 48;

--- a/ASCII_Lib.h
+++ b/ASCII_Lib.h
@@ -1,5 +1,9 @@
 #ifndef ASCII_LIB_H
 #define ASCII_LIB_H
+#include <SDL/SDL.h>
+#include <math.h>
+#include "def.h"
+
 
 // Print an ASCII character
 void drawChr(int x, int y, int smiley, SDL_Surface* source, SDL_Surface* destination, Uint32 color);

--- a/ASCII_Template.cpp
+++ b/ASCII_Template.cpp
@@ -1,4 +1,4 @@
-#include "SDL.h"        //Include SDL functions and datatypes
+#include <SDL/SDL.h>        //Include SDL functions and datatypes
 #include "def.h"        //Colors
 #include "ASCII_Lib.h"  //Drawing functions
 


### PR DESCRIPTION
Greetings,

I got rid of the itoa() function call (this is no longer supported in many compilers), and included SDL/SDL.h instead of simply SDL.h, as is now necessary. The code now compiles well with g++. Thanks for your work on this project! I am working on a roguelike with someone else and I don't want to spend a lot of time messing with SDL. This library solves our problem. We'll give credit, of course.

I hope you see this someday, but it looks like you haven't bin on Git in 3 years...
